### PR TITLE
Lint code (based on skeleton) + Fix a weird behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,34 @@ env:
       VERSION: 7
     - DISTRIBUTION: ubuntu
       VERSION: 16.04
+#    - DISTRIBUTION: debian
+#      VERSION: 9
 
 services:
   - docker
 
 before_install:
-    # Install latest Git
+  # Install latest Git
   - sudo apt-get update
   - sudo apt-get install --only-upgrade git
-    # Allow fetching other branches than master
+  # Allow fetching other branches than master
   - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-    # Fetch the branch with test code
+  # Fetch the branch with test code
   - git fetch origin docker-tests
   - git worktree add docker-tests origin/docker-tests
+  # Lint
+  - sudo pip install --upgrade pip
+  - sudo pip install ansible-lint yamllint
 
 script:
+  # Lint
+  - ansible-lint . -x ANSIBLE0016
+  - yamllint .
+
   # Create container and apply test playbook
   - ./docker-tests/docker-tests.sh
 
   # Run functional tests on the container
   - SUT_ID=$(docker ps -qa) ./docker-tests/functional-tests.sh
+  #- SUT_IP=172.17.0.2 ./docker-tests/functional-tests.sh
+...

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,72 @@
+---
+ignore:
+  env/**/*
+rules:
+  braces:
+    level: error
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  brackets:
+    level: error
+    min-spaces-inside: 1
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
+  colons:
+    level: error
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: error
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    level: error
+    require-starting-space: false
+    min-spaces-from-content: 2
+  comments-indentation: disable
+  document-end:
+    level: error
+    present: true
+  document-start:
+    level: error
+    present: true
+  empty-lines:
+    level: error
+    max: 2
+    max-start: 0
+    max-end: 0
+  empty-values:
+    level: error
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  hyphens:
+    level: error
+    max-spaces-after: 1
+  indentation:
+    level: error
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  key-ordering: disable
+  line-length:
+    level: error
+    max: 120
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: false
+  new-line-at-end-of-file: enable
+  new-lines:
+    level: error
+    type: unix
+  octal-values:
+    level: error
+    forbid-implicit-octal: false
+    forbid-explicit-octal: false
+  trailing-spaces: enable
+  truthy:
+    level: error
+...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ openio_gridinit_limits:
   stack_size: 8192
 
 openio_gridinit_services: []
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
 - name: reload gridinit
   gridinitcmd:
     state: reload
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Romain ACCIARI <romain@openio.io>
+  author: Romain ACCIARI <romain.acciari@openio.io>
   description: Install and configure gridinit for OPENIO
   company: OpenIO
   license: Apache

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,215 +1,22 @@
+---
 galaxy_info:
-  author: Romain Acciari
+  author: Romain ACCIARI <romain@openio.io>
   description: Install and configure gridinit for OPENIO
-  company: OPENIO
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
+  company: OpenIO
   license: Apache
 
   min_ansible_version: 2.4
 
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
-  #
-  # Below are all platforms currently available. Just uncomment
-  # the ones that apply to your role. If you don't see your
-  # platform on this list, let us know and we'll get it added!
-  #
   platforms:
-  #- name: OpenBSD
-  #  versions:
-  #  - all
-  #  - 5.6
-  #  - 5.7
-  #  - 5.8
-  #  - 5.9
-  #  - 6.0
-  #- name: Fedora
-  #  versions:
-  #  - all
-  #  - 16
-  #  - 17
-  #  - 18
-  #  - 19
-  #  - 20
-  #  - 21
-  #  - 22
-  #  - 23
-  #  - 24
-  #  - 25
-  #- name: DellOS
-  #  versions:
-  #  - all
-  #  - 10
-  #  - 6
-  #  - 9
-  #- name: MacOSX
-  #  versions:
-  #  - all
-  #  - 10.10
-  #  - 10.11
-  #  - 10.12
-  #  - 10.7
-  #  - 10.8
-  #  - 10.9
-  #- name: Synology
-  #  versions:
-  #  - all
-  #  - any
-  #- name: Junos
-  #  versions:
-  #  - all
-  #  - any
-  #- name: GenericBSD
-  #  versions:
-  #  - all
-  #  - any
-  #- name: Void Linux
-  #  versions:
-  #  - all
-  #  - any
-  #- name: GenericLinux
-  #  versions:
-  #  - all
-  #  - any
-  #- name: NXOS
-  #  versions:
-  #  - all
-  #  - any
-  #- name: IOS
-  #  versions:
-  #  - all
-  #  - any
-  #- name: Amazon
-  #  versions:
-  #  - all
-  #  - 2013.03
-  #  - 2013.09
-  #  - 2016.03
-  #  - 2016.09
-  #- name: ArchLinux
-  #  versions:
-  #  - all
-  #  - any
-  #- name: FreeBSD
-  #  versions:
-  #  - all
-  #  - 10.0
-  #  - 10.1
-  #  - 10.2
-  #  - 10.3
-  #  - 11.0
-  #  - 8.0
-  #  - 8.1
-  #  - 8.2
-  #  - 8.3
-  #  - 8.4
-  #  - 9.0
-  #  - 9.1
-  #  - 9.1
-  #  - 9.2
-  #  - 9.3
-  - name: Ubuntu
-    versions:
-  #  - all
-  #  - lucid
-  #  - maverick
-  #  - natty
-  #  - oneiric
-  #  - precise
-  #  - quantal
-  #  - raring
-  #  - saucy
-  #  - trusty
-  #  - utopic
-  #  - vivid
-  #  - wily
-    - xenial
-  #  - yakkety
-  #- name: Debian
-  #  versions:
-  #  - all
-  #  - etch
-  #  - jessie
-  #  - lenny
-  #  - sid
-  #  - squeeze
-  #  - stretch
-  #  - wheezy
-  #- name: Alpine
-  #  versions:
-  #  - all
-  #  - any
-  - name: EL
-    versions:
-  #  - all
-  #  - 5
-  #  - 6
-    - 7
-  #- name: Windows
-  #  versions:
-  #  - all
-  #  - 2012R2
-  #- name: SmartOS
-  #  versions:
-  #  - all
-  #  - any
-  #- name: opensuse
-  #  versions:
-  #  - all
-  #  - 12.1
-  #  - 12.2
-  #  - 12.3
-  #  - 13.1
-  #  - 13.2
-  #- name: SLES
-  #  versions:
-  #  - all
-  #  - 10SP3
-  #  - 10SP4
-  #  - 11
-  #  - 11SP1
-  #  - 11SP2
-  #  - 11SP3
-  #  - 11SP4
-  #  - 12
-  #  - 12SP1
-  #- name: GenericUNIX
-  #  versions:
-  #  - all
-  #  - any
-  #- name: Solaris
-  #  versions:
-  #  - all
-  #  - 10
-  #  - 11.0
-  #  - 11.1
-  #  - 11.2
-  #  - 11.3
-  #- name: eos
-  #  versions:
-  #  - all
-  #  - Any
+    - name: Ubuntu
+      versions:
+        - xenial
+    - name: EL
+      versions:
+        - 7
 
   galaxy_tags:
     - system
-    - openio
-    - gridinit
 
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.
@@ -220,7 +27,7 @@ galaxy_info:
     # alphanumeric characters. Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
-
+# List your role dependencies here, one per line.
+# Be sure to remove the '[]' above if you add dependencies
+# to this list.
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,8 +51,6 @@
   template:
     src: gridinit.conf.j2
     dest: "{{ openio_gridinit_config_file }}"
-  with_items: "{{ openio_gridinit_services }}"
-  when: (item.state | default('present')) == 'present'
   tags: configure
   notify: reload gridinit
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for ansible-role-gridinit
+...


### PR DESCRIPTION
- When `openio_gridinit_services` is equal to  `[]`, the global configuration is not set.
- Review the travis file for add a lint (and lint the files in this role)