### PR TITLE
Add new variable openio_gridinit_conf_per_ns

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,6 @@ openio_gridinit_limits:
 openio_gridinit_conf_location: "{{ openio_gridinit_conf_confd }}/*/*"
 openio_gridinit_services: []
 
+openio_gridinit_per_ns: false
+
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
     state: directory
     mode: 0755
   with_items: "{{ openio_gridinit_services | map(attribute='namespace') | list }}"
+  when: openio_gridinit_per_ns | bool
   tags: install
 
 - name: Add gridinit global configuration file
@@ -57,7 +58,7 @@
 - name: Add gridinit per-service configuration file
   template:
     src: gridinit-service.j2
-    dest: "{{ openio_gridinit_conf_confd }}/{{ item.namespace }}/{{ item.name }}.conf"
+    dest: "{{ openio_gridinit_conf_confd + '/' + item.namespace + '/' + item.name + '.conf' if openio_gridinit_per_ns else openio_gridinit_conf_confd + '/' + item.namespace + '-' + item.name + '.conf' }}"
   with_items: "{{ openio_gridinit_services }}"
   when: (item.state | default('present')) == 'present'
   tags: configure
@@ -65,7 +66,7 @@
 
 - name: Remove gridinit per-service configuration file
   file:
-    path: "{{ openio_gridinit_conf_confd }}/{{ item.namespace }}/{{ item.name }}.conf"
+    path: "{{ openio_gridinit_conf_confd + '/' + item.namespace + '/' + item.name + '.conf' if openio_gridinit_per_ns else openio_gridinit_conf_confd + '/' + item.namespace + '-' + item.name + '.conf' }}"
     state: absent
   with_items: "{{ openio_gridinit_services }}"
   when: (item.state | default('present')) == 'absent'


### PR DESCRIPTION
Add new variable openio_gridinit_conf_per_ns that changes the default
behaviour of gridinit to match the old fashion we are currently
using. openio_gridinit_conf_per_ns stores service files in the namespace
directory, which will be the default in the future.