### PR TITLE
FEATURE(gridinit): Allow gridinit to be started at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ An Ansible role for gridinit. Specifically, the responsibilities of this role ar
 | `openio_gridinit_group` | `root` | Group to run |
 | `openio_gridinit_config_file` | `/etc/gridinit.conf` | Path to the parent configuration file |
 | `openio_gridinit_conf_confd` | `/etc/gridinit.d` | Path to the service's folder (by namespace) |
+| `openio_gridinit_enabled` | `false` | Enable gridinit service on boot |
 | `openio_gridinit_rundir` | `/run/gridinit` | Path to the tmpfs subfolder |
 | `openio_gridinit_limits` | `dict` | Defines the max open files and limits for coredump |
 | `openio_gridinit_conf_location` | `{{ openio_gridinit_conf_confd }}/*/*` | Path of configurations to load |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,4 +18,5 @@ openio_gridinit_per_ns: false
 openio_gridinit_conf_location: "{% if openio_gridinit_per_ns %}{{ openio_gridinit_conf_confd }}/*/*
 {%- else %}{{ openio_gridinit_conf_confd }}/*{% endif %}"
 openio_gridinit_services: []
+openio_gridinit_enabled: false
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,7 @@ if openio_gridinit_per_ns else openio_gridinit_conf_confd + '/' + item.namespace
   service:
     name: "{{ openio_gridinit_service_name }}"
     state: started
+    enabled: "{{ openio_gridinit_enabled }}"
   tags: configure
 
 ...


### PR DESCRIPTION
 ##### ISSUE TYPE
- Feature

 ##### SUMMARY
In SDS, we do not want a server come back to the flow at its boot (example: after several months of absence), but for a server oiofs-standalone this makes sense.

 ##### SCOPE (skeleton only)
- gridinit

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION