### PR TITLE
TEST(gridinit): Change for ansible 2.9 and python3, drop of xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 # .travis.yml Execution script for role tests on Travis-CI
 ---
-dist: xenial
+dist: bionic
 sudo: required
 
 env:
   global:
-    - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.9
   matrix:
     - DISTRIBUTION: centos
       VERSION: 7
 #    - DISTRIBUTION: centos
 #      VERSION: 8
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+#    - DISTRIBUTION: ubuntu
+#      VERSION: 16.04
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
 #    - DISTRIBUTION: debian
@@ -20,6 +20,10 @@ env:
 
 services:
   - docker
+
+language: python
+python:
+  - "3.6"
 
 before_install:
   # Install latest Git

--- a/docker-tests/README.md
+++ b/docker-tests/README.md
@@ -1,15 +1,18 @@
 # Docker test environment
 
-This branch contains a test environment for the gridinit role, powered by Docker. It can be used to either run tests locally, or remotely on [Travis-CI](https://travis-ci.org/).  [git-worktree(1)](https://git-scm.com/docs/git-worktree) is used to include the test code into the working directory. Remark that this requires at least Git v2.5.0.
-
-1. Fetch the test branch: `git fetch origin docker-tests`
-2. Create a Git worktree for the test code: `git worktree add docker-tests docker-tests`. This will create a directory `docker-tests/`
-3. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/bertvv/ansible-testing/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
+1. The script `docker-tests.sh` will create a Docker container, and apply this role from a playbook `<test.yml>`. The Docker images are configured for testing Ansible roles and are published at <https://hub.docker.com/r/cdelgehier/docker_images_ansible/>. There are images available for several distributions and versions. The distribution and version should be specified outside the script using environment variables:
 
     ```
-    DISTRIBUTION=centos VERSION=7 ./docker-tests/docker-tests.sh
+    DISTRIBUTION=centos VERSION=7 ANSIBLE_VERSION=2.9 ./docker-tests/docker-tests.sh
+    DISTRIBUTION=ubuntu VERSION=18.04 ANSIBLE_VERSION=2.9 ./docker-tests/docker-tests.sh
     ```
+2. You can test another use case by adding an argument to the script. An argument `<another>` will apply a playbook `<another.yml>`
 
-    The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.
+3. You can run functionnal tests locally like that:
 
-
+    ```
+    SUT_ID=9acda29c356b ./docker-tests/functional-tests.sh
+    SUT_IP=172.17.0.2   ./docker-tests/functional-tests.sh
+    ```
+   
+The specific combinations of distributions and versions that are supported by this role are specified in `.travis.yml`.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,12 +5,12 @@ galaxy_info:
   company: OpenIO
   license: Apache
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
+        - bionic
     - name: EL
       versions:
         - 7


### PR DESCRIPTION
 ##### SUMMARY

Update .travis.yml according to our new requirements.
Update meta/main.yml too.

 ##### IMPACT
 N/A

 ##### ADDITIONAL INFORMATION