### PR TITLE
BUGFIX/MINOR(SDS): Fix check status

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,6 +97,8 @@ if openio_gridinit_per_ns else openio_gridinit_conf_confd + '/' + item.namespace
       changed_when: false
       tags: configure
       failed_when:
-        - "'Connection refused' in _gridinit_check.stdout"
+        - |
+          'Connection refused' in _gridinit_check.stdout
+            or 'Connection to UNIX socket' in _gridinit_check.stderr
   when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
 ##### SUMMARY

Currently, the check is not complete.
Error output is now also checked.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```console
root@89151ef71735 /]# gridinit_cmd status
Connection to UNIX socket [/run/gridinit/gridinit.sock] failed : No such file or directory
KEY  STATUS      PID GROUP
[root@89151ef71735 /]# systemctl status gridinit
● gridinit.service - Gridinit daemon from OpenIO
   Loaded: loaded (/usr/lib/systemd/system/gridinit.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
[root@89151ef71735 /]# systemctl start gridinit
[root@89151ef71735 /]# gridinit_cmd status
KEY             STATUS      PID GROUP
JENKINS-redis-0 UP         2225 JENKINS,redis,0
```