### PR TITLE
CHANGE(gridinit): move variables from `vars` to `default`

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,2 @@
 ---
-# vars file for ansible-role-gridinit
 ...


### PR DESCRIPTION
 ##### SUMMARY
in `vars` should only remain variables that must be fixed.
All the others must be set in `defaults` (almost all variables).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION