### PR TITLE
CHANGE(gridinit): load `.conf` files only

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,8 +15,8 @@ openio_gridinit_limits:
   stack_size: 8192
 
 openio_gridinit_per_ns: false
-openio_gridinit_conf_location: "{% if openio_gridinit_per_ns %}{{ openio_gridinit_conf_confd }}/*/*
-{%- else %}{{ openio_gridinit_conf_confd }}/*{% endif %}"
+openio_gridinit_conf_location: "{% if openio_gridinit_per_ns %}{{ openio_gridinit_conf_confd }}/*/*.conf
+{%- else %}{{ openio_gridinit_conf_confd }}/*.conf{% endif %}"
 openio_gridinit_services: []
 openio_gridinit_enabled: false
 ...


### PR DESCRIPTION
 ##### SUMMARY

Currently, gridinit load any files from `gridinit.d` directory which can
be temporary files (from ansible, from vi, ...) and it can cause strange
behavior

 ##### IMPACT
Files which does not end with `.conf` won't be loaded any more

 ##### ADDITIONAL INFORMATION