### PR TITLE
CHANGE(gridinit): load `.conf` files only

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ openio_gridinit_limits:
   stack_size: 8192
 
 openio_gridinit_per_ns: false
-openio_gridinit_conf_location: "{{ openio_gridinit_includes | d(openio_gridinit_conf_confd ~ '/{*,*/*}') }}"
+openio_gridinit_conf_location: "{{ openio_gridinit_includes | d(openio_gridinit_conf_confd ~ '/{*.conf,*/*.conf}') }}"
 openio_gridinit_services: []
 openio_gridinit_enabled: "{{ openio_services_systemd_enabled | d(true) | bool }}"
 ...


### PR DESCRIPTION
 ##### SUMMARY

Currently, gridinit load any files from `gridinit.d` directory which can
be temporary files (from ansible, from vi, ...) and it can cause strange
behavior

 ##### IMPACT
Files which does not end with `.conf` won't be loaded any more

 ##### ADDITIONAL INFORMATION

(cherry picked from commit 6aabcbb433780191d009258cef59c8a903a8b773)
(cherry picked from commit bbbe2a7ff3d949c1cd86b34d799f2864afb40191)